### PR TITLE
Add posted date to photos

### DIFF
--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -33,6 +33,10 @@ class Photo
     return I18n.t :anonymous_user
   end
 
+  def posted_on
+    created_at.to_date
+  end
+
   private
 
   def ensure_well_formed_url

--- a/app/views/arts/show.html.erb
+++ b/app/views/arts/show.html.erb
@@ -176,6 +176,7 @@
             <% else %>
                 <a href="<%= @art.primary_photo.attribution_url %>"> <%= @art.primary_photo.attribution_text_for_display %></a>.
             <% end %>
+            <%= t(:posted_on, date: l(@art.primary_photo.posted_on)) %>.
           </div>
       <% end %>
 
@@ -187,6 +188,7 @@
               <% else %>
                   <a  href="<%= photo.attribution_url %>"> <%= photo.attribution_text_for_display %></a>.
               <% end %>
+              <%= t(:posted_on, date: l(photo.posted_on)) %>
             </div>
         <% end %>
         <div id="artThumbs">
@@ -213,9 +215,9 @@
         </div>
       <% end %>
 
-      <span class="tip">
+      <div class="tip">
         All photos uploaded are licensed under a <a href="http://creativecommons.org/licenses/by-nc/3.0/">Creative Commons Attribution-NonCommercial license</a>.
-      </span>
+      </div>
     </div>
 
     <div class="module">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,9 +6,13 @@ en:
   photo_attribution_text: "Photo attribution (optional)"
   photo_attribution_url: "Attribution URL (optional)"
   photo_by: "Photo by"
+  posted_on: "Posted on %{date}"
   anonymous_user: "anonymous user"
   views:
     pagination:
       previous: "&lt; Previous"
       next: "Next &gt;"
       truncate: "..."
+  date:
+    formats:
+      default: "%B %d, %Y"


### PR DESCRIPTION
- change default date format
- add posted_on method to photo which returns creation date (without time)
- add posted on date to templates