### PR TITLE
Revert "Changes for solve bug of task 1."

### DIFF
--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -7,7 +7,7 @@ class Photo
 
   attr_protected :_id
 
-  field :pic_date , :type => Date, :default => nil
+  field :pic_date , :type => Date, :default => Date.new(2015,1,1)
   field :attribution_text, :type => String
   field :attribution_url, :type => String
   field :primary, :type => Boolean, :default => false

--- a/lib/tasks/initialize_data.rake
+++ b/lib/tasks/initialize_data.rake
@@ -28,11 +28,4 @@ namespace :initialize do
     
     puts "Loaded #{Art.count} art pieces into the database."
   end
-
-  task :udate_pic_date => :environment do
-    Photo.all.each do |p|
-      p.pic_date = p.created_at
-      p.save
-    end  
-  end  
 end


### PR DESCRIPTION
Reverts ArtAround/artaround-web#70

Why duplicate created_at field?  We can simply use the created_at date for the photo directly.