### PR TITLE
Change for filter and all other for web

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery
   layout "application"
 
+
   # saves the art, creates a photo and saves it, returns the Photo object
   def create_photo(art, image, attribution_text = nil, attribution_url = nil)
     art.photos.new(
@@ -37,6 +38,8 @@ class ApplicationController < ActionController::Base
                     "Statue", "Stained glass", "Temporary", "Textile",
                     "Video"]
   end
+  
+  
 
   helper_method :neighborhoods
   def neighborhoods

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -33,4 +33,5 @@ module ApplicationHelper
     end
     host
   end
+ 
 end

--- a/app/views/admin/arts/show.html.erb
+++ b/app/views/admin/arts/show.html.erb
@@ -8,6 +8,18 @@
     var map;
     var searchMarker;
 
+    <% if @art.category.present? %>
+        var art_category = "<%=@art.category[0] %>"
+    <%else%>
+      var art_category = "Unknown"
+    <%end%>
+
+    <% if @art.tag.present? %>
+        var art_tag = "<%=@art.tag[0]%>"
+    <%else%>
+      var art_tag = "Unknown"
+    <%end%>
+
     function loadMaps() {
 
       <% if @art.latitude and @art.longitude %>
@@ -58,6 +70,28 @@
 
       searchMarker = new google.maps.Marker({position: location});
       searchMarker.setMap(map);
+
+      art_category = art_category.toLowerCase();
+      art_tag = art_tag.toLowerCase();
+      if ( art_category == "catalog" || art_tag == "catalog") {
+        icon = "teal.png"
+      }
+      else if ( art_category == "street art host spots" ||  art_tag == "street art host spots") {
+        icon = "yellow.png"
+      }
+      else if ( art_category == "museum" || art_tag == "museum" ||  art_category == "art gallery" || art_tag == "art gallery" ||  art_category == "outdoor gallery" || art_tag == "outdoor gallery" ||  art_category == "gallery" || art_tag == "gallery") {
+        icon = "blue.png"
+      }
+      else if ( art_category == "artchive" || art_tag == "artchive") {
+        icon = "grey.png"
+      }
+      else {
+        icon = "red.png"
+      }
+      var pinImage = "/images/pins/"+icon;
+      searchMarker.setIcon(pinImage); 
+
+
 
       $("input#art_latitude").val(location.lat());
       $("input#art_longitude").val(location.lng());

--- a/app/views/arts/_filter_category.html.erb
+++ b/app/views/arts/_filter_category.html.erb
@@ -1,0 +1,34 @@
+
+<div id="art-list">
+  <% @arts.each do |art| %>
+
+    <% unless art.photos.empty? %>
+      <% categories = art.category || [] %>
+      <% classes = "#{categories.map{|x| x.downcase}.join(' ')} #{art.title.downcase.split.join('-')}" %>
+      <% unless art.artist.nil? %>
+        <%# classes = classes + art.artist.downcase.split.join('-') %>
+      <% end %>
+      <div class="art <%= classes %>">
+        <a href="<%= art_path(art) %>">
+          <img class="" src="<%= art.primary_photo.image :big %>"/>
+        </a>
+        <h3><%= link_to art.title, art %></h3>
+       
+        <%if known(art.artist).kind_of?(Array)%>
+       
+          <% known(art.artist).each do |a| %>
+          <h4><%= a %></h4>
+          <% end %>
+        <%else%>
+          <% if art.artist.blank? %>
+            <h4>Unknown</h4>
+          <%else%>
+            <h4><%= art.artist %></h4>
+          <%end%>
+        <%end%>
+        <small class="created_at" style="display:none;"><%= art.created_at.strftime("%Y%m%d%H%M") %></small>
+        <small class="visits" style="display:none;"><%= art.total_visits %></small>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/arts/filter_category.js.erb
+++ b/app/views/arts/filter_category.js.erb
@@ -1,0 +1,1 @@
+$('#filter_category').html("<%= escape_javascript(render('/arts/filter_category') )%>");

--- a/app/views/arts/index.html.erb
+++ b/app/views/arts/index.html.erb
@@ -107,11 +107,12 @@ jQuery(function($) {
   </ul>
   <%if controller_name == 'arts'%>
   <div id="filters">
-  <form method="get" action="/" id="filter-form">
+ <!--  <form method="get" action="/" id="filter-form"> -->
     <b style="margin: 5px;" >TAGS</b>
-    <%= select_tag "tag_filter", options_for_select((['All']+Tag.all.collect(&:name)).sort_by!{ |e| e.downcase }), {prompt: "show all"}%>
-    
-    <b style="margin: 5px;" >CATEGORIES</b>
+    <%= select_tag "tag", options_for_select((Tag.all.collect(&:name)).sort_by!{ |e| e.downcase }), {prompt: "all"}%>
+    <%= select_tag "category", options_for_select(['all']+categories)%>
+
+   <!--  <b style="margin: 5px;" >CATEGORIES</b>
     <select name="filter">
       <option value="">show all</option>
       <option value="architecture">Architecture</option>
@@ -141,48 +142,45 @@ jQuery(function($) {
       <option value="temporary">Temporary</option>
       <option value="textile">Textile</option>
       <option value="video">Video</option>
-    </select>
+    </select> -->
     <input id="sort-value" type="hidden" name="sort" value="" />
     <br>
-    <button class="submit" style="float: right; margin-top: 5px;" >Filter</button>
-    </form>
+    <button class="category_submit" style="float: right; margin-top: 5px;" >Filter</button>
+    <!-- </form> -->
   </div>
   <%end%>
   <div class="clear"></div>
 </div>
+<div id="filter_category">
+  <%=render '/arts/filter_category'%>
+</div> 
 
-<div id="art-list" >
-  <% @arts.each do |art| %>
-    <% unless art.photos.empty? %>
-      <% categories = art.category || [] %>
-      <% classes = "#{categories.map{|x| x.downcase}.join(' ')} #{art.title.downcase.split.join('-')}" %>
-      <% unless art.artist.nil? %>
-        <%# classes = classes + art.artist.downcase.split.join('-') %>
-      <% end %>
-      <div class="art <%= classes %>">
-        <a href="<%= art_path(art) %>">
-          <img class="" src="<%= art.primary_photo.image :big %>"/>
-        </a>
-        <h3><%= link_to art.title, art %></h3>
-        <%if known(art.artist).kind_of?(Array)%>
-          <% known(art.artist).each do |a| %>
-          <h4><%= a %></h4>
-          <% end %>
-        <%else%>
-        <h4><%= art.artist %></h4>
-        <%end%>
-        
-        <small class="created_at" style="display:none;"><%= art.created_at.strftime("%Y%m%d%H%M") %></small>
-        <small class="visits" style="display:none;"><%= art.total_visits %></small>
-      </div>
-    <% end %>
-  <% end %>
-</div>
+
 </div>
 
 <%= paginate @arts %>
 
 <script>
+  $(document).on('click', '.category_submit', function(){
+    var category=$('#category').val();
+    var tag=$('#tag').val();
+    var sort=$('#sort-value').val();
+    debugger
+    $.ajax({
+      method: 'GET',
+      url: '/arts/filter_category',
+      data: {category: category, tag: tag, sort: sort },
+      success: function(){   
+        var $container = $('#art-list');
+        $container.isotope({
+          itemSelector : '.art',
+          sortBy: 'created_at'
+        });
+        $('#art-list').isotope({ sortBy : 'created_at', sortAscending : true});
+      }
+    });    
+  });
+
   function setup_isotope(){
     var $container = $('#art-list');
 
@@ -213,10 +211,12 @@ jQuery(function($) {
     //   $container.isotope({ filter: selector });
     //   return false;
     // });
+
     $('#art-list').isotope({ sortBy : 'created_at', sortAscending : true});
   }
 
   $(window).load(function(){
+    
     if (window.location.search.replace( "?", "").split("&").indexOf("sort=popular") != -1){
       $('#recent').removeClass("current");
       $('#popular').addClass("current");

--- a/app/views/arts/map.html.erb
+++ b/app/views/arts/map.html.erb
@@ -45,6 +45,7 @@
     <% end %>
 
     <% @arts.each do |art| %>
+
       arts.push({
         id: "<%= art.to_param %>",
         event_id: "<%= art.event_id %>",
@@ -69,7 +70,11 @@
         ward: "<%= art.ward %>",
         popular: <%= art.popular? %>,
         description: "<%= escape_javascript art.description %>",
-        artist: "<%= escape_javascript art.artist.to_s %>",
+        <%if art.artist.blank? %>
+          artist: "<%= escape_javascript art.artist.reject!{|a| a==[]}.to_s %>",
+        <% else%>
+          artist: "<%= escape_javascript art.artist.to_s %>",
+        <% end%>
         year: "<%= escape_javascript art.year.to_s %>",
         timeline_year: <%= art.timeline_year %>,
         map_thumb: "<%= art.primary_photo ? art.primary_photo.image(:small) : "" %>",
@@ -119,6 +124,7 @@
       icons.grey = new google.maps.MarkerImage("/images/pins/grey.png");
 
       $.each(arts, function(i, art) {
+        
         var marker = markerFor(art, map);
 
         marker.filters = {
@@ -187,7 +193,7 @@
 		    '<p>' + (description || "(no description)") + '<a class="moreInfo" href="/arts/' + art.id + '" target="_blank">More Info</a></p>' +
 
       '</div>';
-
+      
       var icon = icons.art;
       var isVenue = ($.inArray('museum', art.category)>=0 || $.inArray('gallery', art.category)>=0 || $.inArray('market', art.category)>=0);
       if (isVenue){
@@ -538,12 +544,12 @@
 
     jQuery(document).ready(function ($) {
         var $imgs = $('img.lazy'),
+       
                 $container = $('#art-list');
 
         $imgs.lazyload({
             'failure_limit' : Math.max($imgs.length - 1, 0)
         });
-
         $imgs.load(function () {
             $container.isotope('reLayout');
         });

--- a/app/views/arts/new.html.erb
+++ b/app/views/arts/new.html.erb
@@ -114,16 +114,59 @@
         }
       });
 
+     
+
       google.maps.event.addListener(map, "click", function(event) {
+       
         $("input#art_latitude").val(event.latLng.lat());
         $("input#art_longitude").val(event.latLng.lng());
+
+        var art_category = $("#art_category").val();
+        var art_tag = $("#art_tag").val();
+        
+        if (art_category == null) {
+          art_category = "Unknown"
+        }
+        else {
+          art_category = art_category[0].toLowerCase();
+        }
+
+        if (art_tag == null) {
+          art_tag = "Unknown"
+        }
+        else {
+          art_tag = art_tag[0].toLowerCase();
+        }
+
+        if ( art_category == "catalog" || art_tag == "catalog") {
+          icon = "teal.png"
+        }
+        else if ( art_category == "street art host spots" ||  art_tag == "street art host spots") {
+          icon = "yellow.png"
+        }
+        else if ( art_category == "museum" || art_tag == "museum" ||  art_category == "art gallery" || art_tag == "art gallery" ||  art_category == "outdoor gallery" || art_tag == "outdoor gallery" || art_category == "gallery" || art_tag == "gallery") {
+          icon = "blue.png"
+        }
+        else if ( art_category == "artchive" || art_tag == "artchive") {
+          icon = "grey.png"
+        }
+        else {
+          icon = "red.png"
+        }
+        var pinImage = "/images/pins/"+icon;
+        marker.setIcon(pinImage); 
+
         marker.setPosition(event.latLng);
         marker.setMap(map);
+        
       });
 
     }
+    
+
 
     $(function() {
+
       var lat, lng;
       lat = $("input#art_latitude").val();
       lng = $("input#art_longitude").val();
@@ -150,6 +193,8 @@
         geoLocate();
       }
     });
+
+
   </script>
 <% end %>
 
@@ -194,16 +239,17 @@
         <div id="first_slide">
           <li>
             <label for="art_category">category</label>
-            <%= f.select :category, categories, {}, {:multiple => true, :style => "width: 350px"}  %>
+            <%= f.select :category, categories, {}, {:multiple => true, :style => "width: 350px"} %>
           </li>
-          <!-- <li>
+          
+          <li>
             <label for="art_tag">Tags</label>
-            <%#= f.select :tag, Tag.all.collect(&:name), {}, {:multiple => true, :style => "width: 350px"}  %>
+            <%= f.select :tag, Tag.all.collect(&:name), {}, {:multiple => true, :style => "width: 350px"}  %>
+          </li>
+           <!-- <li>
+            <label for="art_tag">Tags</label>
+            <%#= f.select('tag_id', Tag.all.collect {|r| [h(r.name), r.id] }, {}, { :include_blank => false, :multiple => true, :style => "width: 350px"}) %>
           </li> -->
-           <li>
-            <label for="art_tag">Tags</label>
-            <%= f.select('tag_id', Tag.all.collect {|r| [h(r.name), r.id] }, {}, { :include_blank => false, :multiple => true, :style => "width: 350px" }) %>
-          </li>
           <li>
             <label for="art_title">title<sup>*</sup></label>
             <%= f.text_field :title %>

--- a/app/views/arts/show.html.erb
+++ b/app/views/arts/show.html.erb
@@ -13,6 +13,7 @@
 <% end %>
 
 <script type="text/javascript">
+
   var latitude = <%= @art.latitude || 0 %>;
   var longitude = <%= @art.longitude || 0 %>;
 
@@ -20,6 +21,20 @@
   var city = "<%= @art.city %>";
   var state = "<%= @art.state %>";
   var zip = "<%= @art.zip %>";
+
+  <% if @art.category.present? %>
+      var art_category = "<%=@art.category[0] %>"
+  <%else%>
+    var art_category = "Unknown"
+  <%end%>
+
+  <% if @art.tag.present? %>
+      var art_tag = "<%=@art.tag.last%>"
+  <%else%>
+    var art_tag = "Unknown"
+  <%end%>
+
+
 
   function loadMaps() {
 
@@ -36,6 +51,27 @@
     var marker = new google.maps.Marker({
       position: location
     });
+    art_category = art_category.toLowerCase();
+    art_tag = art_tag.toLowerCase();
+    if ( art_category == "catalog" || art_tag == "catalog") {
+      icon = "teal.png"
+    }
+    else if ( art_category == "street art host spots" ||  art_tag == "street art host spots") {
+      icon = "yellow.png"
+    }
+    else if ( art_category == "museum" || art_tag == "museum" ||  art_category == "art gallery" || art_tag == "art gallery" ||  art_category == "outdoor gallery" || art_tag == "outdoor gallery" ||  art_category == "gallery" || art_tag == "gallery") {
+      icon = "blue.png"
+    }
+    else if ( art_category == "artchive" || art_tag == "artchive") {
+      icon = "grey.png"
+    }
+    else {
+      icon = "red.png"
+    }
+    var pinImage = "/images/pins/"+icon;
+    marker.setIcon(pinImage); 
+
+
     marker.setMap(map);
   }
 
@@ -239,10 +275,12 @@
         <!-- <dd><%#= known @art.artist %></dd> -->
         <dd>
           <ul>
+          
           <% if !@art.artist.blank? %>
-            <%if @art.artist[1].present?%>
+            <%if @art.artist.present?%>
               <%if @art.artist.kind_of?(Array)%>
                 <% @art.artist.each do |a| %>
+
                   <li><%=link_to a ,artist_path(a)%></li>
                 <% end %>
               <%else%>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,4 +33,5 @@ Artaround::Application.configure do
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :test
   config.action_mailer.perform_deliveries = true
+  
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,4 +51,5 @@ Artaround::Application.configure do
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = true
+  
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Artaround::Application.routes.draw do
     get :index, :on => :collection
     post :manage_link ,:on => :collection
     get :destroy_link, :on => :member
+    get :filter_category, :on => :collection
+    
   end
 
   namespace :admin do


### PR DESCRIPTION
1. Filtering by Category from homepage toggle bar doesn’t show a complete list of all posts in
that Category
- But filtering by Tag does render a complete list (pointing to URLs like http://
staging.theartaround.us/tag/San%20Francisco) - Done

2. “Tags” field does not render on artwork entry backend for all previously added artworks
**So we are unable to test if the tags bug has been remedied
- TAGS title show up with no entry field beneath Done

3. Previously added artworks show up with the correct color pin on the map, but the pins for
newly added artworks remain red regardless of which tags or categories are applied - Done

4. Newly added artist names show up inside a bracket and quotation marks on the map - Done